### PR TITLE
Improve installation steps for macOS

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,9 +100,9 @@ sudo cp sga_linux_amd64/* /usr/local/bin
 <details><summary>macOS installation</summary><p>
 
 ```
-brew install autossh ssh-askpass
-curl -L https://api.github.com/repos/StanfordSNR/guardian-agent/releases/latest | grep browser_download_url | grep 'darwin' | cut -d'"' -f 4 | xargs curl -L | tar xzv
-sudo cp sga_darwin_amd64/* /usr/local/bin
+brew tap theseal/ssh-askpass
+brew tap theseal/guardian-agent
+brew install guardian-agent
 ```
 
 </p>


### PR DESCRIPTION
Created a tap which contains `guardian-agent` to make the installation
much easier on macOS.

I'm not sure which `ssh-askpass` the documentation referred to as there
is no one in homebrew by default. I took the opportunity to add mine and
@simmel tap which I think is the most populare one right now.