### PR TITLE
AskPassUI: honor environment variable SSH_ASKPASS

### DIFF
--- a/agent.go
+++ b/agent.go
@@ -37,7 +37,7 @@ func NewGuardian(policyConfigPath string, inType InputType) (*Agent, error) {
 		ui = &FancyTerminalUI{}
 		break
 	case Display:
-		ui = &AskPassUI{}
+		ui = NewAskPassUI()
 	}
 
 	// get policy store


### PR DESCRIPTION
On modern GNU/Linux distributions `ssh-askpass` is installed in `libexecdir`: [Arch Linux x11-ssh-askpass](https://www.archlinux.org/packages/extra/x86_64/x11-ssh-askpass/)

Users most likely setup this environment variable in their desktop environment:
```
SSH_ASKPASS=/usr/lib/ssh/ssh-askpass 
```

Fixes this issue for me:

```
execution denied by agent: Failed to get user approval: exec: "ssh-askpass": executable file not found in $PATH
```